### PR TITLE
Adding payload option for delete requests

### DIFF
--- a/dhis2/api.py
+++ b/dhis2/api.py
@@ -276,14 +276,16 @@ class Dhis(object):
         json = kwargs['data'] if 'data' in kwargs else json
         return self._make_request('patch', endpoint, data=json, params=params)
 
-    def delete(self, endpoint, params=None):
+    def delete(self, endpoint, json=None, params=None, **kwargs):
         """
         DELETE from DHIS2
         :param endpoint: DHIS2 API endpoint
+        :param json: HTTP payload
         :param params: HTTP parameters (dict)
         :return: requests.Response object
         """
-        return self._make_request('delete', endpoint, params=params)
+        json = kwargs['data'] if 'data' in kwargs else json
+        return self._make_request('delete', endpoint, data=json, params=params)
 
     def get_paged(self, endpoint, params=None, page_size=50, merge=False):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,10 +70,11 @@ def test_patch(api):
 @responses.activate
 def test_delete(api):
     url = '{}/organisationUnits/uid?a=b'.format(API_URL)
+    p = {"obj": "some data"}
 
-    responses.add(responses.DELETE, url, status=200)
+    responses.add(responses.DELETE, url, json=p, status=200)
 
-    api.delete(endpoint='organisationUnits/uid', params={'a': 'b'})
+    api.delete(endpoint='organisationUnits/uid', json=p, params={'a': 'b'})
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == url


### PR DESCRIPTION
In some rare cases such as updating collections like dataElementGroups a payload is required with a delete api request. For example the DHIS2 2.29 [dev manual in section 1.9.4.2](https://docs.dhis2.org/2.29/en/developer/dhis2_developer_manual.pdf#page=24) shows an example of bulk removal of data elements from a dataElementGroup.

I have made changes to allow json or data parameters for delete.